### PR TITLE
feat: external scanner engine slots + clickable Fix with Claude

### DIFF
--- a/docs/scanner-engines.md
+++ b/docs/scanner-engines.md
@@ -20,20 +20,27 @@ CCO includes a built-in security scanner with 60+ detection rules. For deeper sc
 | **[agent-audit](https://github.com/HeadyZhang/agent-audit)** | 53 | AST taint analysis, OWASP Agentic Top 10 (ASI-01 to ASI-10), "missing control" detection (no kill switch, no rate limit), memory poisoning | `pip install agent-audit` | MIT |
 | **[mcp-audit](https://github.com/apisec-inc/mcp-audit)** | 60 | Secrets exposure, shadow API inventory, AI-BOM (CycloneDX), endpoint classification, OWASP LLM Top 10 | `pip install mcp-audit` | MIT |
 
-## Why external engines?
+## Built-in vs external — they scan different things
 
-CCO's built-in scanner is fast and catches the most common threats. But specialized engines go deeper:
+**Built-in scanner (recommended first):** Connects to each MCP server via JSON-RPC, retrieves actual tool definitions, and scans descriptions for prompt injection and hidden instructions. This is the primary attack surface — tool descriptions go straight into Claude's context as trusted text.
 
-- **cc-audit** has false-positive exclusions that reduce noise (14+ exclusion patterns per rule vs zero in built-in)
-- **AgentSeal** uses machine learning to catch rephrased attacks that bypass regex
-- **agent-audit** does AST-level taint analysis — tracking data from tool inputs to dangerous sinks
-- **mcp-audit** generates AI-BOMs (software bill of materials) that enterprise security teams require
+**External scanners (complementary):** Scan your config files for supply chain risks, credential exposure, CVEs, and permission issues. They do NOT connect to MCP servers or read tool definitions — they check the config text itself.
 
-You don't have to choose one. Install multiple and switch between them in the dropdown to get different perspectives on the same configs.
+| What gets scanned | Built-in | External |
+|-------------------|:---:|:---:|
+| **Tool descriptions** (prompt injection, hidden instructions) | **Yes** | No |
+| **Tool schemas** (suspicious parameter names) | **Yes** | No |
+| Supply chain (unpinned packages, known malicious) | Basic | **Deep** |
+| Credential exposure (API keys, secrets) | Basic | **Deep** |
+| CVE checks (known vulnerabilities) | No | **Yes** |
+| File permissions (world-readable configs) | No | **Yes** |
+| Config hygiene (missing auth, insecure URLs) | No | **Yes** |
+
+**Best practice: run built-in first** (catches the dangerous stuff — hidden instructions in tool descriptions), then run an external engine for supply chain and config hygiene.
 
 ## CCO's advantage
 
-Other scanners produce reports. CCO produces **navigation**. When any engine finds an issue, you click the finding and land directly on the MCP server entry in the scope tree. Delete it, move it, or inspect its config — without leaving CCO.
+Other scanners produce reports. CCO produces **navigation**. When any engine finds an issue, you click "Fix with Claude →" to copy a detailed prompt — including the engine name, rule ID, server path, and suggested fix — ready to paste into Claude Code.
 
 ## Output format support
 

--- a/docs/scanner-engines.md
+++ b/docs/scanner-engines.md
@@ -1,0 +1,45 @@
+# Scanner Engines
+
+CCO includes a built-in security scanner with 60+ detection rules. For deeper scanning, you can plug in any compatible external engine. CCO auto-detects installed engines and adds them to the scanner dropdown.
+
+## How it works
+
+1. Install any engine below
+2. Open CCO → Security Scan panel
+3. The engine appears in the dropdown automatically
+4. Select it and click "Start Security Scan"
+5. Results show in CCO with click-to-navigate — click any finding to jump to the MCP server entry
+
+## Compatible Engines
+
+| Engine | Rules | What it catches | Install | License |
+|--------|------:|-----------------|---------|---------|
+| **Built-in** | 60+ | Prompt injection, tool poisoning, credential exposure, data exfiltration, code execution | Included | MIT |
+| **[cc-audit](https://github.com/ryo-ebata/cc-audit)** | 184 | Everything above + persistence (crontab, systemd, LaunchAgent), Docker security, supply chain, privilege escalation. False-positive handling. CWE IDs. Auto-fix. | `npm i -g @cc-audit/cc-audit` | MIT |
+| **[AgentSeal](https://github.com/AgentSeal/agentseal)** | 400+ | Semantic ML detection (MiniLM), TR39 confusable characters, dataflow analysis, 225 adversarial probes, MCP registry trust scores (6,600+ servers) | `pip install agentseal` | FSL-1.1 |
+| **[agent-audit](https://github.com/HeadyZhang/agent-audit)** | 53 | AST taint analysis, OWASP Agentic Top 10 (ASI-01 to ASI-10), "missing control" detection (no kill switch, no rate limit), memory poisoning | `pip install agent-audit` | MIT |
+| **[mcp-audit](https://github.com/apisec-inc/mcp-audit)** | 60 | Secrets exposure, shadow API inventory, AI-BOM (CycloneDX), endpoint classification, OWASP LLM Top 10 | `pip install mcp-audit` | MIT |
+
+## Why external engines?
+
+CCO's built-in scanner is fast and catches the most common threats. But specialized engines go deeper:
+
+- **cc-audit** has false-positive exclusions that reduce noise (14+ exclusion patterns per rule vs zero in built-in)
+- **AgentSeal** uses machine learning to catch rephrased attacks that bypass regex
+- **agent-audit** does AST-level taint analysis — tracking data from tool inputs to dangerous sinks
+- **mcp-audit** generates AI-BOMs (software bill of materials) that enterprise security teams require
+
+You don't have to choose one. Install multiple and switch between them in the dropdown to get different perspectives on the same configs.
+
+## CCO's advantage
+
+Other scanners produce reports. CCO produces **navigation**. When any engine finds an issue, you click the finding and land directly on the MCP server entry in the scope tree. Delete it, move it, or inspect its config — without leaving CCO.
+
+## Output format support
+
+CCO accepts two output formats from external scanners:
+
+- **SARIF** (Static Analysis Results Interchange Format) — industry standard, used by cc-audit and agent-audit
+- **JSON** — generic findings array, used by AgentSeal and mcp-audit
+
+If you build your own scanner, output SARIF and CCO will pick it up automatically.

--- a/src/security-scanner.mjs
+++ b/src/security-scanner.mjs
@@ -21,6 +21,326 @@ const BASELINE_DIR = join(HOME, ".claude", ".cco-security");
 const BASELINE_PATH = join(BASELINE_DIR, "baselines.json");
 
 // ══════════════════════════════════════════════════════════════════════
+// EXTERNAL SCANNER ENGINE SUPPORT
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Registry of known external security scanner engines.
+ * CCO auto-detects installed ones and lets users switch between them.
+ * Each scanner's CLI is called with a path and returns SARIF or JSON findings.
+ */
+const EXTERNAL_SCANNERS = [
+  {
+    id: "cc-audit",
+    name: "cc-audit",
+    description: "Claude Code security auditor — 184 rules, false-positive handling, CWE IDs",
+    url: "https://github.com/ryo-ebata/cc-audit",
+    detectCmd: ["cc-audit", ["--version"]],
+    scanCmd: (path) => ["cc-audit", ["scan", path, "--format", "sarif", "--quiet"]],
+    outputFormat: "sarif",
+    license: "MIT",
+  },
+  {
+    id: "agentseal",
+    name: "AgentSeal",
+    description: "400+ rules — semantic ML detection, TR39 confusables, adversarial probes",
+    url: "https://github.com/AgentSeal/agentseal",
+    detectCmd: ["agentseal", ["--help"]],
+    scanCmd: (path) => ["agentseal", ["guard", path, "--output", "json", "--no-diff", "--no-registry"]],
+    outputFormat: "json-agentseal",
+    license: "FSL-1.1-Apache-2.0",
+  },
+  {
+    id: "agent-audit",
+    name: "agent-audit",
+    description: "OWASP Agentic Top 10 — AST taint analysis, 53 rules",
+    url: "https://github.com/HeadyZhang/agent-audit",
+    detectCmd: ["agent-audit", ["--version"]],
+    scanCmd: (path) => ["agent-audit", ["scan", path, "--format", "sarif"]],
+    outputFormat: "sarif",
+    license: "MIT",
+  },
+  {
+    id: "mcp-audit",
+    name: "mcp-audit",
+    description: "Secrets, shadow APIs, AI-BOM generation — 60 rules",
+    url: "https://github.com/apisec-inc/mcp-audit",
+    detectCmd: ["mcp-audit", ["--version"]],
+    scanCmd: (path) => ["mcp-audit", ["scan", path, "--format", "json"]],
+    outputFormat: "json-generic",
+    license: "MIT",
+  },
+];
+
+/**
+ * Detect which external scanners are installed on the system.
+ * Returns array of scanner objects with `installed: true/false` and `version`.
+ */
+async function detectExternalScanners() {
+  const results = [];
+
+  for (const scanner of EXTERNAL_SCANNERS) {
+    try {
+      const [cmd] = scanner.detectCmd;
+      // Use 'which' (Unix) or 'where' (Windows) to detect if binary exists
+      const whichCmd = process.platform === "win32" ? "where" : "which";
+      const binPath = await new Promise((resolve, reject) => {
+        execFile(whichCmd, [cmd], { timeout: 3000 }, (err, stdout) => {
+          if (err) reject(err);
+          else resolve(stdout.trim().split("\n")[0]);
+        });
+      });
+
+      // Try to get version (best-effort, not required)
+      let version = "installed";
+      try {
+        const [, args] = scanner.detectCmd;
+        const out = await new Promise((resolve, reject) => {
+          execFile(cmd, args, { timeout: 5000 }, (err, stdout) => {
+            if (err) resolve(""); // Some tools don't support --version
+            else resolve(stdout.trim().split("\n")[0]);
+          });
+        });
+        if (out) version = out;
+      } catch { /* version detection is optional */ }
+
+      results.push({ ...scanner, installed: true, version, binPath });
+    } catch {
+      results.push({ ...scanner, installed: false, version: null, binPath: null });
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Run an external scanner engine and parse its output into CCO finding format.
+ * @param {string} scannerId - ID from EXTERNAL_SCANNERS registry
+ * @param {string} scanPath - Path to scan (usually ~/.claude/)
+ * @returns {object} Scan results in CCO format
+ */
+async function runExternalScan(scannerId, scanPath) {
+  const scanner = EXTERNAL_SCANNERS.find(s => s.id === scannerId);
+  if (!scanner) throw new Error(`Unknown scanner: ${scannerId}`);
+
+  const [cmd, args] = scanner.scanCmd(scanPath);
+
+  const rawOutput = await new Promise((resolve, reject) => {
+    execFile(cmd, args, { timeout: 120000, maxBuffer: 10 * 1024 * 1024 }, (err, stdout, stderr) => {
+      // Some scanners exit non-zero when findings exist — that's normal
+      if (err && !stdout) reject(new Error(`${scanner.name} failed: ${err.message}\n${stderr}`));
+      else resolve(stdout);
+    });
+  });
+
+  let parsed;
+  try {
+    parsed = JSON.parse(rawOutput);
+  } catch {
+    throw new Error(`${scanner.name} returned invalid JSON. First 200 chars: ${rawOutput.slice(0, 200)}`);
+  }
+
+  // Convert to CCO finding format based on output type
+  if (scanner.outputFormat === "sarif") {
+    return parseSarifFindings(parsed, scanner);
+  }
+  // Generic JSON: expect { findings: [...] } or similar
+  return parseGenericFindings(parsed, scanner);
+}
+
+/**
+ * Parse SARIF (Static Analysis Results Interchange Format) into CCO findings.
+ * SARIF spec: https://docs.oasis-open.org/sarif/sarif/v2.1.0/
+ */
+function parseSarifFindings(sarif, scanner) {
+  const findings = [];
+
+  for (const run of (sarif.runs || [])) {
+    const rules = {};
+    for (const rule of (run.tool?.driver?.rules || [])) {
+      rules[rule.id] = rule;
+    }
+
+    for (const result of (run.results || [])) {
+      const ruleId = result.ruleId || "UNKNOWN";
+      const rule = rules[ruleId] || {};
+      const severity = mapSarifSeverity(result.level);
+      const location = result.locations?.[0]?.physicalLocation;
+      const filePath = location?.artifactLocation?.uri || "";
+      const region = location?.region;
+
+      findings.push({
+        id: ruleId,
+        category: rule.properties?.category || mapRuleIdToCategory(ruleId),
+        severity,
+        name: rule.shortDescription?.text || rule.name || ruleId,
+        description: rule.fullDescription?.text || result.message?.text || "",
+        sourceType: "external_scanner",
+        sourceName: `${scanner.name}: ${filePath}`,
+        matchedText: result.message?.text?.slice(0, 200) || "",
+        context: region ? `Line ${region.startLine}${region.startColumn ? `:${region.startColumn}` : ""}` : filePath,
+        externalScanner: scanner.id,
+        externalRuleUrl: rule.helpUri || null,
+        owasp: rule.properties?.owasp || null,
+        cwe: rule.properties?.cwe || extractCweFromTags(rule.properties?.tags),
+      });
+    }
+  }
+
+  return {
+    ok: true,
+    engine: scanner.id,
+    engineName: scanner.name,
+    engineVersion: scanner.version || "unknown",
+    findings,
+    severityCounts: countSeverities(findings),
+  };
+}
+
+/**
+ * Parse generic JSON findings (non-SARIF scanners).
+ * Handles multiple output shapes including AgentSeal's mcp_results/skill_results format.
+ */
+function parseGenericFindings(data, scanner) {
+  const findings = [];
+
+  // AgentSeal format: { mcp_results: [...], skill_results: [...] }
+  if (data.mcp_results || data.skill_results) {
+    for (const result of (data.mcp_results || [])) {
+      for (const f of (result.findings || [])) {
+        findings.push({
+          id: f.code || "EXT",
+          category: mapAgentSealCode(f.code),
+          severity: normalizeSeverity(f.severity),
+          name: f.title || f.code,
+          description: f.description || "",
+          sourceType: "external_scanner",
+          sourceName: `${scanner.name}: ${result.name}`,
+          serverName: result.name,  // MCP server name — for click-to-navigate
+          matchedText: f.remediation || "",
+          context: result.source_file || result.command || "",
+          externalScanner: scanner.id,
+          externalRuleUrl: null,
+          owasp: null,
+          cwe: f.code?.startsWith("MCP-CVE") ? f.title : null,
+        });
+      }
+    }
+    for (const result of (data.skill_results || [])) {
+      for (const f of (result.findings || [])) {
+        findings.push({
+          id: f.code || "EXT",
+          category: mapAgentSealCode(f.code),
+          severity: normalizeSeverity(f.severity),
+          name: f.title || f.code,
+          description: f.description || "",
+          sourceType: "external_scanner",
+          sourceName: `${scanner.name}: ${result.name}`,
+          matchedText: f.remediation || "",
+          context: result.path || "",
+          externalScanner: scanner.id,
+        });
+      }
+    }
+    return {
+      ok: true,
+      engine: scanner.id,
+      engineName: scanner.name,
+      engineVersion: scanner.version || "unknown",
+      scanDuration: data.duration_seconds ? `${data.duration_seconds.toFixed(1)}s` : null,
+      findings,
+      severityCounts: countSeverities(findings),
+    };
+  }
+
+  // Generic format: { findings: [...] } or { results: [...] }
+  const rawFindings = data.findings || data.results || data.vulnerabilities || [];
+
+  for (const f of rawFindings) {
+    findings.push({
+      id: f.id || f.rule_id || f.ruleId || "EXT",
+      category: f.category || f.type || "external",
+      severity: normalizeSeverity(f.severity || f.level || "medium"),
+      name: f.name || f.title || f.rule || f.id || "Finding",
+      description: f.description || f.message || f.detail || "",
+      sourceType: "external_scanner",
+      sourceName: `${scanner.name}: ${f.file || f.path || f.source || ""}`,
+      matchedText: f.matched_text || f.match || f.evidence || "",
+      context: f.context || f.location || "",
+      externalScanner: scanner.id,
+      externalRuleUrl: f.url || f.help_url || null,
+      owasp: f.owasp || null,
+      cwe: f.cwe || null,
+    });
+  }
+
+  return {
+    ok: true,
+    engine: scanner.id,
+    engineName: scanner.name,
+    engineVersion: scanner.version || "unknown",
+    findings,
+    severityCounts: countSeverities(findings),
+  };
+}
+
+/** Map AgentSeal finding codes to CCO categories. */
+function mapAgentSealCode(code) {
+  if (!code) return "external";
+  if (code.startsWith("MCP-CVE")) return "supply_chain";
+  if (code.startsWith("MCP-007")) return "supply_chain";
+  if (code.startsWith("MCP-011")) return "sensitive_access";
+  if (code.startsWith("MCP-")) return "mcp_config";
+  if (code.startsWith("SKILL-")) return "prompt_injection";
+  return "external";
+}
+
+/** Map SARIF severity levels to CCO severity. */
+function mapSarifSeverity(level) {
+  const map = { error: "high", warning: "medium", note: "low", none: "info" };
+  return map[level] || "medium";
+}
+
+/** Normalize various severity strings to CCO's 5 levels. */
+function normalizeSeverity(sev) {
+  const s = String(sev).toLowerCase();
+  if (s === "critical" || s === "crit") return "critical";
+  if (s === "high" || s === "error" || s === "danger") return "high";
+  if (s === "medium" || s === "warning" || s === "warn" || s === "moderate") return "medium";
+  if (s === "low" || s === "note" || s === "minor") return "low";
+  return "info";
+}
+
+/** Try to extract CWE from SARIF rule tags. */
+function extractCweFromTags(tags) {
+  if (!Array.isArray(tags)) return null;
+  const cweTag = tags.find(t => /^CWE-\d+$/i.test(t));
+  return cweTag || null;
+}
+
+/** Map rule ID prefixes to categories (fallback). */
+function mapRuleIdToCategory(ruleId) {
+  const prefix = ruleId.split("-")[0]?.toUpperCase();
+  const map = {
+    PI: "prompt_injection", TP: "tool_poisoning", TS: "tool_shadowing",
+    SF: "sensitive_access", DE: "data_exfiltration", CH: "credential_harvest",
+    CE: "code_execution", CI: "command_injection", HK: "suspicious_hook",
+    SC: "supply_chain", PE: "persistence", XR: "cross_server_ref",
+    ASI: "owasp_agentic", EX: "exfiltration",
+  };
+  return map[prefix] || "external";
+}
+
+/** Count severities from a findings array. */
+function countSeverities(findings) {
+  const counts = { critical: 0, high: 0, medium: 0, low: 0, info: 0 };
+  for (const f of findings) {
+    if (counts[f.severity] !== undefined) counts[f.severity]++;
+  }
+  return counts;
+}
+
+// ══════════════════════════════════════════════════════════════════════
 // LAYER 1: DEOBFUSCATION (8 techniques from AgentSeal deobfuscate.py)
 // ══════════════════════════════════════════════════════════════════════
 
@@ -873,4 +1193,7 @@ export async function runSecurityScan(introspectionResults, scanData) {
   };
 }
 
-export { deobfuscate, scanText, PATTERNS, loadBaselines, compareBaselines, updateBaselines };
+export {
+  deobfuscate, scanText, PATTERNS, loadBaselines, compareBaselines, updateBaselines,
+  detectExternalScanners, runExternalScan, EXTERNAL_SCANNERS,
+};

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -14,7 +14,7 @@ import { scan } from "./scanner.mjs";
 import { moveItem, deleteItem, getValidDestinations } from "./mover.mjs";
 import { countTokens, getMethod } from "./tokenizer.mjs";
 import { introspectServers } from "./mcp-introspector.mjs";
-import { runSecurityScan, checkClaudeAvailable, llmJudge } from "./security-scanner.mjs";
+import { runSecurityScan, checkClaudeAvailable, llmJudge, detectExternalScanners, runExternalScan } from "./security-scanner.mjs";
 
 // ── Update check ─────────────────────────────────────────────────────
 async function checkForUpdate() {
@@ -758,9 +758,67 @@ async function handleRequest(req, res) {
     return json(res, { ok: true, ...status });
   }
 
+  // GET /api/security-scanners — detect installed external scanner engines
+  if (path === "/api/security-scanners" && req.method === "GET") {
+    try {
+      const scanners = await detectExternalScanners();
+      return json(res, { ok: true, scanners });
+    } catch (err) {
+      return json(res, { ok: false, error: err.message }, 500);
+    }
+  }
+
   // POST /api/security-scan — run full security scan (introspect + pattern + baseline)
+  // Accepts optional body: { engine: "cc-audit" | "agentseal" | "built-in" (default) }
   if (path === "/api/security-scan" && req.method === "POST") {
     try {
+      const body = await readBody(req).catch(() => ({}));
+      const engine = body?.engine || "built-in";
+
+      // External scanner engine
+      if (engine !== "built-in") {
+        const claudeDir = join(homedir(), ".claude");
+        const externalResults = await runExternalScan(engine, claudeDir);
+
+        // Merge with introspection data for click-to-navigate
+        if (!cachedData) await freshScan();
+        const mcpItems = cachedData.items.filter(i => i.category === "mcp" && i.mcpConfig);
+
+        // Map external findings to MCP server scope for click-to-navigate
+        for (const finding of externalResults.findings) {
+          // AgentSeal already sets serverName from mcp_results[].name
+          const name = finding.serverName;
+          const matchedServer = name
+            ? mcpItems.find(m => m.name === name)
+            : mcpItems.find(m =>
+                finding.sourceName?.includes(m.name) || finding.context?.includes(m.name)
+              );
+          if (matchedServer) {
+            finding.serverName = matchedServer.name;
+            finding.scopeId = matchedServer.scopeId;
+          }
+        }
+
+        return json(res, {
+          ...externalResults,
+          timestamp: new Date().toISOString(),
+          totalServers: mcpItems.length,
+          serversConnected: mcpItems.length,
+          serversFailed: 0,
+          totalTools: 0,
+          servers: mcpItems.map(m => ({
+            serverName: m.name,
+            scopeId: m.scopeId,
+            status: "external",
+            toolCount: 0,
+            tools: [],
+            findings: externalResults.findings.filter(f => f.serverName === m.name),
+          })),
+          baselines: [],
+        });
+      }
+
+      // Built-in scanner (original behavior)
       if (!cachedData) await freshScan();
 
       // Get all MCP server items from scan data

--- a/src/ui/app.js
+++ b/src/ui/app.js
@@ -2786,7 +2786,8 @@ function renderSecurityResults(scanData) {
           persistence: "Persistence", cross_server_ref: "Cross-Server",
           mcp_config: "MCP Config", external: "Security",
         }[f.category] || f.category;
-        html += `<span class="sec-category-label">${esc(categoryLabel)}</span>`;
+        const ruleId = (f.id && f.id !== "EXT") ? `${f.id} · ` : "";
+        html += `<span class="sec-category-label">${esc(ruleId + categoryLabel)}</span>`;
         html += `</div>`;
         // Description
         if (f.description) {

--- a/src/ui/app.js
+++ b/src/ui/app.js
@@ -2792,16 +2792,45 @@ function renderSecurityResults(scanData) {
         if (f.description) {
           html += `<div class="sec-finding-desc">${esc(f.description)}</div>`;
         }
-        // Remediation (from external scanners)
+        // Remediation — clickable, copies prompt for Claude Code
         if (f.matchedText && f.externalScanner) {
-          html += `<div class="sec-finding-fix">💡 ${esc(f.matchedText)}</div>`;
+          const engineName = scanData.engineName || f.externalScanner;
+          const serverName = f.serverName || server;
+          const configPath = f.context || "~/.claude/.mcp.json";
+          const prompt = [
+            `I found a security issue in my MCP server "${serverName}" at ${configPath}:`,
+            ``,
+            `Issue: ${f.name} (${categoryLabel})`,
+            `Severity: ${f.severity}`,
+            `${f.description}`,
+            ``,
+            `Detected by: ${engineName} (rule ${f.id})`,
+            `Suggested fix: ${f.matchedText}`,
+            ``,
+            `Please evaluate the root cause of this issue, confirm whether this fix is appropriate for my setup, and guide me through applying it if needed.`,
+          ].join("\n");
+          const promptAttr = esc(prompt).replace(/"/g, "&quot;");
+          html += `<div class="sec-finding-fix sec-fix-clickable" data-fix-prompt="${promptAttr}" title="Click to copy prompt for Claude Code">💡 ${esc(f.matchedText)} <span class="sec-fix-action">Fix with Claude →</span></div>`;
+        } else if (f.matchedText && !f.externalScanner) {
+          // Built-in scanner — also make clickable
+          const prompt = [
+            `I found a security issue in my MCP server "${server}":`,
+            ``,
+            `Issue: ${f.name}`,
+            `Severity: ${f.severity}`,
+            `Matched: ${f.matchedText}`,
+            `Context: ${f.context || ""}`,
+            ``,
+            `Detected by: CCO built-in scanner (rule ${f.id})`,
+            ``,
+            `Please evaluate this finding, explain the risk, and help me fix it if needed.`,
+          ].join("\n");
+          const promptAttr = esc(prompt).replace(/"/g, "&quot;");
+          html += `<div class="sec-finding-fix sec-fix-clickable" data-fix-prompt="${promptAttr}" title="Click to copy prompt for Claude Code">💡 ${esc(f.matchedText.length > 120 ? f.matchedText.slice(0, 120) + "…" : f.matchedText)} <span class="sec-fix-action">Fix with Claude →</span></div>`;
         }
-        // Source context (matched text for built-in, file path for external)
+        // Source context (file path for external)
         if (f.context && !f.externalScanner) {
           html += `<div class="sec-finding-context">${esc(f.context)}</div>`;
-        } else if (f.matchedText && !f.externalScanner) {
-          const truncMatch = f.matchedText.length > 120 ? f.matchedText.slice(0, 120) + "…" : f.matchedText;
-          html += `<div class="sec-finding-context">${esc(truncMatch)}</div>`;
         }
         // External rule link
         if (f.externalRuleUrl) {
@@ -2855,6 +2884,29 @@ function renderSecurityResults(scanData) {
       if (items) {
         const hidden = items.classList.toggle("hidden");
         btn.textContent = hidden ? "▸" : "▾";
+      }
+    });
+  });
+
+  // "Fix with Claude →" click → copy prompt to clipboard
+  results.querySelectorAll(".sec-fix-clickable").forEach(el => {
+    el.addEventListener("click", async (e) => {
+      e.stopPropagation();
+      const prompt = el.dataset.fixPrompt;
+      if (!prompt) return;
+      try {
+        await navigator.clipboard.writeText(prompt);
+        toast("Prompt copied — paste in Claude Code");
+      } catch {
+        // Fallback for non-HTTPS
+        const ta = document.createElement("textarea");
+        ta.value = prompt;
+        ta.style.cssText = "position:fixed;opacity:0";
+        document.body.appendChild(ta);
+        ta.select();
+        document.execCommand("copy");
+        document.body.removeChild(ta);
+        toast("Prompt copied — paste in Claude Code");
       }
     });
   });

--- a/src/ui/app.js
+++ b/src/ui/app.js
@@ -2398,15 +2398,63 @@ let securityScanResults = null;
 let securityBadges = {};
 /** Map of MCP server name → baseline status ("new" | "changed" | null). */
 let securityBaselineStatus = {};
+/** Detected external scanner engines. */
+let detectedScanners = [];
+
+/** Detect installed external scanners and populate dropdown. */
+async function loadExternalScanners() {
+  const select = document.getElementById("securityEngineSelect");
+  const info = document.getElementById("securityEngineInfo");
+  if (!select) return;
+
+  try {
+    const resp = await fetch("/api/security-scanners");
+    const result = await resp.json();
+    if (!result.ok) return;
+
+    detectedScanners = result.scanners.filter(s => s.installed);
+    const allScanners = result.scanners || [];
+
+    if (detectedScanners.length > 0) {
+      // Add installed scanners to dropdown
+      for (const scanner of detectedScanners) {
+        const opt = document.createElement("option");
+        opt.value = scanner.id;
+        opt.textContent = `${scanner.name} (${scanner.description.split("—")[0].trim()})`;
+        select.appendChild(opt);
+      }
+    }
+
+    // Always show "Add more engines" link at bottom
+    const notInstalled = allScanners.filter(s => !s.installed);
+    if (notInstalled.length > 0 || allScanners.length > 0) {
+      info.innerHTML = `<a href="https://github.com/mcpware/claude-code-organizer/blob/main/docs/scanner-engines.md" target="_blank">+ Add scanner engines</a>`;
+    }
+
+    select.addEventListener("change", () => {
+      const selected = detectedScanners.find(s => s.id === select.value);
+      if (selected) {
+        info.innerHTML = `<a href="${selected.url}" target="_blank">${selected.license}</a> · <a href="https://github.com/mcpware/claude-code-organizer/blob/main/docs/scanner-engines.md" target="_blank">+ More</a>`;
+      } else {
+        info.innerHTML = `<a href="https://github.com/mcpware/claude-code-organizer/blob/main/docs/scanner-engines.md" target="_blank">+ Add scanner engines</a>`;
+      }
+    });
+  } catch {
+    // Even if detection fails, show the link
+    info.innerHTML = `<a href="https://github.com/mcpware/claude-code-organizer/blob/main/docs/scanner-engines.md" target="_blank">+ Add scanner engines</a>`;
+  }
+}
 
 function setupSecurityScan() {
   const btn = document.getElementById("securityScanBtn");
   const panel = document.getElementById("securityPanel");
   const closeBtn = document.getElementById("securityClose");
   const startBtn = document.getElementById("securityStartBtn");
-  const rescanBtn = document.getElementById("securityRescanBtn");
 
   if (!btn) return;
+
+  // Detect external scanners (non-blocking)
+  loadExternalScanners();
 
   // Cached results + new server check loaded in init() before renderAll
 
@@ -2419,7 +2467,14 @@ function setupSecurityScan() {
       await runSecurityScan();
     } else if (securityScanResults) {
       renderSecurityResults(securityScanResults);
+      // Sync dropdown with cached results engine
+      const cachedEngine = securityScanResults.engine || "built-in";
+      const select = document.getElementById("securityEngineSelect");
+      if (select && [...select.options].some(o => o.value === cachedEngine)) {
+        select.value = cachedEngine;
+      }
     }
+    // Otherwise show intro with engine selector — user clicks "Start Security Scan"
   });
 
   closeBtn?.addEventListener("click", () => {
@@ -2427,10 +2482,6 @@ function setupSecurityScan() {
   });
 
   startBtn?.addEventListener("click", async () => {
-    await runSecurityScan();
-  });
-
-  rescanBtn?.addEventListener("click", async () => {
     await runSecurityScan();
   });
 
@@ -2531,11 +2582,21 @@ async function runSecurityScan() {
   progressBar.classList.remove("security-bar-error");
   progressText.textContent = "Connecting to MCP servers...";
 
-  try {
-    progressBar.style.width = "20%";
-    progressText.textContent = "Fetching tool definitions from MCP servers...";
+  // Disable scan button during scan
+  const scanBtn = document.getElementById("securityStartBtn");
+  if (scanBtn) { scanBtn.disabled = true; scanBtn.textContent = "Scanning..."; }
 
-    const resp = await fetch("/api/security-scan", { method: "POST" });
+  try {
+    const engineName = document.getElementById("securityEngineSelect")?.selectedOptions[0]?.textContent || "Built-in";
+    progressBar.style.width = "20%";
+    progressText.textContent = `Scanning with ${engineName}...`;
+
+    const selectedEngine = document.getElementById("securityEngineSelect")?.value || "built-in";
+    const resp = await fetch("/api/security-scan", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ engine: selectedEngine }),
+    });
     const scanData = await resp.json();
 
     progressBar.style.width = "90%";
@@ -2570,6 +2631,9 @@ async function runSecurityScan() {
       else if (b.hasChanges) securityBaselineStatus[b.serverName] = "changed";
     }
 
+    // Re-enable scan button
+    if (scanBtn) { scanBtn.disabled = false; scanBtn.textContent = "▶ Scan"; }
+
     renderSecurityResults(scanData);
     // Re-render main list — badges only on servers with findings, clean servers get cleared
     renderAll();
@@ -2578,30 +2642,31 @@ async function runSecurityScan() {
     // Clear NEW flags (baselines updated), but check for CHANGED servers
     securityBaselineStatus = {};
     const changedCount = (scanData.baselines || []).filter(b => b.hasChanges && !b.isFirstScan).length;
-    const scanBtn = document.getElementById("securityScanBtn");
+    const sidebarBtn = document.getElementById("securityScanBtn");
 
-    if (changedCount > 0 && scanBtn) {
+    if (changedCount > 0 && sidebarBtn) {
       // Servers changed since last scan — re-shimmer + CHANGED badges
       for (const b of (scanData.baselines || [])) {
         if (b.hasChanges && !b.isFirstScan) securityBaselineStatus[b.serverName] = "changed";
       }
-      scanBtn.classList.add("sec-btn-alert");
-      scanBtn.querySelector(".sec-btn-tooltip")?.remove();
+      sidebarBtn.classList.add("sec-btn-alert");
+      sidebarBtn.querySelector(".sec-btn-tooltip")?.remove();
       const tip = document.createElement("span");
       tip.className = "sec-btn-tooltip";
       tip.textContent = `${changedCount} MCP server${changedCount > 1 ? "s" : ""} changed — click to rescan`;
-      scanBtn.appendChild(tip);
+      sidebarBtn.appendChild(tip);
       renderAll(); // re-render to show CHANGED badges
-    } else if (scanBtn) {
+    } else if (sidebarBtn) {
       // All clear — remove shimmer + tooltip + re-render to clear badges
-      scanBtn.classList.remove("sec-btn-alert");
-      scanBtn.querySelector(".sec-btn-tooltip")?.remove();
+      sidebarBtn.classList.remove("sec-btn-alert");
+      sidebarBtn.querySelector(".sec-btn-tooltip")?.remove();
       renderAll();
     }
 
   } catch (err) {
     progressText.textContent = `Error: ${err.message}`;
     progressBar.classList.add("security-bar-error");
+    if (scanBtn) { scanBtn.disabled = false; scanBtn.textContent = "▶ Scan"; }
   }
 }
 
@@ -2613,7 +2678,7 @@ function renderSecurityResults(scanData) {
 
   progress.classList.add("hidden");
   results.classList.remove("hidden");
-  document.getElementById("securityRescanBtn")?.classList.remove("hidden");
+  // Rescan handled by main security button shimmer alert — no separate rescan button needed
   footer.classList.remove("hidden");
 
   const { severityCounts, totalTools, totalServers, serversConnected, baselines, findings } = scanData;
@@ -2662,8 +2727,8 @@ function renderSecurityResults(scanData) {
     // Group findings by server name
     const byServer = {};
     for (const f of findings) {
-      const parts = (f.sourceName || "").split("/");
-      const server = parts[0] || "unknown";
+      // External scanners set serverName directly; built-in uses sourceName "server/tool" format
+      const server = f.serverName || (f.sourceName || "").split("/")[0] || "unknown";
       if (!byServer[server]) byServer[server] = [];
       byServer[server].push(f);
     }
@@ -2707,9 +2772,41 @@ function renderSecurityResults(scanData) {
       for (const f of deduped) {
         const bc = f.severity === "critical" ? "sec-critical" : f.severity === "high" ? "sec-high" : f.severity === "medium" ? "sec-medium" : "sec-low";
         const countLabel = f.count > 1 ? ` ×${f.count}` : "";
-        html += `<div class="sec-finding-row" data-sec-server="${esc(server)}" data-sec-scope="${esc(scopeId)}">`;
+        html += `<div class="sec-finding-item" data-sec-server="${esc(server)}" data-sec-scope="${esc(scopeId)}">`;
+        html += `<div class="sec-finding-header">`;
         html += `<span class="sec-badge ${bc}" style="font-size:9px;padding:0 4px">${esc(f.severity.charAt(0).toUpperCase())}</span>`;
         html += `<span class="sec-finding-label">${esc(f.name)}${countLabel}</span>`;
+        // Category label (human-readable, not cryptic rule codes)
+        const categoryLabel = {
+          supply_chain: "Supply Chain", prompt_injection: "Prompt Injection",
+          tool_poisoning: "Tool Poisoning", tool_shadowing: "Tool Shadowing",
+          sensitive_access: "Sensitive Access", data_exfiltration: "Data Exfiltration",
+          credential_harvest: "Credentials", code_execution: "Code Execution",
+          command_injection: "Command Injection", suspicious_hook: "Suspicious Hook",
+          persistence: "Persistence", cross_server_ref: "Cross-Server",
+          mcp_config: "MCP Config", external: "Security",
+        }[f.category] || f.category;
+        html += `<span class="sec-category-label">${esc(categoryLabel)}</span>`;
+        html += `</div>`;
+        // Description
+        if (f.description) {
+          html += `<div class="sec-finding-desc">${esc(f.description)}</div>`;
+        }
+        // Remediation (from external scanners)
+        if (f.matchedText && f.externalScanner) {
+          html += `<div class="sec-finding-fix">💡 ${esc(f.matchedText)}</div>`;
+        }
+        // Source context (matched text for built-in, file path for external)
+        if (f.context && !f.externalScanner) {
+          html += `<div class="sec-finding-context">${esc(f.context)}</div>`;
+        } else if (f.matchedText && !f.externalScanner) {
+          const truncMatch = f.matchedText.length > 120 ? f.matchedText.slice(0, 120) + "…" : f.matchedText;
+          html += `<div class="sec-finding-context">${esc(truncMatch)}</div>`;
+        }
+        // External rule link
+        if (f.externalRuleUrl) {
+          html += `<div class="sec-finding-link"><a href="${esc(f.externalRuleUrl)}" target="_blank">View rule docs →</a></div>`;
+        }
         html += `</div>`;
       }
       html += `</div>`;
@@ -2771,7 +2868,8 @@ function renderSecurityResults(scanData) {
   });
 
   const scanTime = new Date(scanData.timestamp).toLocaleString();
-  footerNote.textContent = `${scanTime}`;
+  const engineLabel = scanData.engineName ? `${scanData.engineName} · ` : "";
+  footerNote.textContent = `${engineLabel}${scanTime}`;
 }
 
 /** Save security scan results to server for persistence across sessions. */

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -150,15 +150,23 @@
     <div class="detail hidden" id="securityPanel">
       <div class="detail-top">
         <h2 id="securityTitle">🛡️ Security Scan</h2>
-        <button class="d-btn d-btn-move security-rescan-btn hidden" id="securityRescanBtn" type="button">Rescan</button>
         <button class="detail-x" id="securityClose" type="button">✕</button>
+      </div>
+
+      <div class="security-action-bar" id="securityActionBar">
+        <div class="security-engine-col">
+          <select class="security-engine-select" id="securityEngineSelect">
+            <option value="built-in">Built-in (60+ rules)</option>
+          </select>
+          <span class="security-engine-info" id="securityEngineInfo"></span>
+        </div>
+        <button class="d-btn d-btn-move security-scan-btn" id="securityStartBtn" type="button">▶ Scan</button>
       </div>
 
       <div class="security-body" id="securityBody">
         <div class="security-intro" id="securityIntro">
           <p>Scan your MCP servers for prompt injection, tool poisoning, credential exposure, and other security threats.</p>
-          <p class="security-note">This connects to each MCP server to inspect tool definitions — the actual attack surface.</p>
-          <button class="d-btn d-btn-move security-start-btn" id="securityStartBtn" type="button">Start Security Scan</button>
+          <p class="security-note">Connects to each MCP server to inspect tool definitions — the actual attack surface.</p>
         </div>
         <div class="security-progress hidden" id="securityProgress">
           <div class="security-progress-text" id="securityProgressText">Connecting to MCP servers...</div>
@@ -170,7 +178,7 @@
       </div>
 
       <div class="security-footer hidden" id="securityFooter">
-        <div class="security-footer-note" id="securityFooterNote"></div>
+        <span class="security-footer-note" id="securityFooterNote"></span>
       </div>
     </div>
   </div>

--- a/src/ui/style.css
+++ b/src/ui/style.css
@@ -1344,6 +1344,16 @@ body {
   font-size: 11px; color: var(--accent); line-height: 1.4;
   margin: 3px 0 0 22px;
 }
+.sec-fix-clickable {
+  cursor: pointer; border-radius: 4px; padding: 2px 6px; margin-left: 18px;
+  transition: background 150ms;
+}
+.sec-fix-clickable:hover { background: var(--accent-light, rgba(99, 179, 237, 0.1)); }
+.sec-fix-action {
+  font-size: 10px; font-weight: 600; opacity: 0; transition: opacity 150ms;
+  margin-left: 6px;
+}
+.sec-fix-clickable:hover .sec-fix-action { opacity: 1; }
 .sec-finding-context {
   font-size: 10px; color: var(--text-muted, var(--fg3)); font-family: monospace;
   margin: 2px 0 0 22px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;

--- a/src/ui/style.css
+++ b/src/ui/style.css
@@ -1213,6 +1213,25 @@ body {
 .security-note { font-size: 11px; color: var(--fg3); }
 .security-start-btn { margin-top: 8px; font-size: 13px; padding: 7px 18px; }
 
+/* ── Security action bar (engine selector + scan button, always visible) ── */
+.security-action-bar {
+  display: flex; align-items: flex-start; gap: 8px;
+  padding: 8px 14px; border-bottom: 1px solid var(--border-light);
+  flex-shrink: 0;
+}
+.security-engine-col { display: flex; flex-direction: column; gap: 2px; flex: 1; min-width: 0; }
+.security-engine-select {
+  font-size: 0.8rem; padding: 4px 8px; border-radius: 5px;
+  background: var(--bg-secondary, var(--bg2)); color: var(--text-primary, var(--fg1));
+  border: 1px solid var(--border-light, var(--border));
+  cursor: pointer; min-width: 0; flex: 1;
+}
+.security-engine-select:focus { outline: 1px solid var(--accent); border-color: var(--accent); }
+.security-engine-info { font-size: 0.68rem; color: var(--text-muted, var(--fg3)); white-space: nowrap; }
+.security-engine-info a { color: var(--accent); text-decoration: none; }
+.security-engine-info a:hover { text-decoration: underline; }
+.security-scan-btn { font-size: 0.8rem; padding: 6px 18px; white-space: nowrap; flex-shrink: 0; font-weight: 600; letter-spacing: 0.3px; }
+
 /* ── Progress bar ── */
 .security-progress-text { font-size: 12px; color: var(--fg2); margin-bottom: 8px; }
 .security-progress-bar-wrap { height: 4px; background: var(--bg2); border-radius: 2px; overflow: hidden; }
@@ -1292,6 +1311,48 @@ body {
 .sec-row-name { flex: 1; font-weight: 600; color: var(--fg); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
 .sec-findings-list { padding-left: 20px; }
+
+/* Finding item — expandable card with details */
+.sec-finding-item {
+  padding: 6px 10px;
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background 100ms;
+  font-size: 11px;
+  border-left: 2px solid transparent;
+  margin-bottom: 2px;
+}
+.sec-finding-item:hover { background: var(--bg-secondary, var(--bg2)); border-left-color: var(--accent); }
+.sec-finding-header { display: flex; align-items: center; gap: 6px; }
+.sec-finding-label { color: var(--text-primary, var(--fg1)); font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 12px; }
+.sec-finding-tags { display: flex; gap: 3px; margin-left: auto; flex-shrink: 0; }
+.sec-tag {
+  font-size: 9px; padding: 1px 5px; border-radius: 3px;
+  background: var(--bg-tertiary, var(--bg3, #2a2a3a)); color: var(--text-primary, var(--fg1));
+  font-family: monospace; white-space: nowrap; margin-left: auto; flex-shrink: 0;
+}
+.sec-category-label {
+  font-size: 9px; padding: 1px 6px; border-radius: 3px;
+  background: var(--accent-light, rgba(99, 179, 237, 0.15)); color: var(--accent);
+  white-space: nowrap; margin-left: auto; flex-shrink: 0; font-weight: 600;
+}
+.sec-finding-desc {
+  font-size: 11px; color: var(--text-primary, var(--fg1)); line-height: 1.4;
+  margin: 3px 0 0 22px; opacity: 0.9;
+}
+.sec-finding-fix {
+  font-size: 11px; color: var(--accent); line-height: 1.4;
+  margin: 3px 0 0 22px;
+}
+.sec-finding-context {
+  font-size: 10px; color: var(--text-muted, var(--fg3)); font-family: monospace;
+  margin: 2px 0 0 22px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.sec-finding-link { font-size: 10px; margin: 2px 0 0 22px; }
+.sec-finding-link a { color: var(--accent); text-decoration: none; }
+.sec-finding-link a:hover { text-decoration: underline; }
+
+/* Keep old class for backward compat */
 .sec-finding-row {
   display: flex;
   align-items: center;
@@ -1303,7 +1364,6 @@ body {
   font-size: 11px;
 }
 .sec-finding-row:hover { background: var(--bg2); }
-.sec-finding-label { color: var(--fg2); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
 /* ── Footer ── */
 .security-footer {


### PR DESCRIPTION
## Summary
- External scanner engine support — auto-detects installed scanners (cc-audit, AgentSeal, agent-audit, mcp-audit) and lets users switch between them in the security panel dropdown
- SARIF + JSON parser converts any external scanner output into CCO findings with click-to-navigate
- Clickable "Fix with Claude →" on every remediation line — copies a detailed prompt including server name, config path, engine name, rule ID, severity, description, and suggested fix
- Human-readable category labels (MCP-007 · Supply Chain) instead of cryptic rule codes
- docs/scanner-engines.md explains compatible engines + how to install

## Test plan
- [x] Playwright E2E: AgentSeal scan → 26 findings → click-to-navigate → zero JS errors
- [x] Playwright E2E: clickable fix → clipboard contains full prompt with engine name, path, severity
- [x] API test: `POST /api/security-scan {engine: "agentseal"}` returns parsed findings
- [x] API test: `GET /api/security-scanners` detects installed scanners
- [ ] Manual: test with cc-audit when GLIBC compatible
- [ ] Manual: test with no scanners installed (shows "+ Add scanner engines" link)

🤖 Generated with [Claude Code](https://claude.com/claude-code)