### PR TITLE
fix: quote argument-hint so YAML parses it as string

### DIFF
--- a/skills/organize/SKILL.md
+++ b/skills/organize/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: organize
 description: Open the Cross-Code Organizer (CCO) dashboard — view and manage all memories, skills, MCP servers, hooks, and configs across scopes
-argument-hint: [--port <number>]
+argument-hint: "[--port <number>]"
 allowed-tools: [Bash, Read]
 ---
 


### PR DESCRIPTION
## Summary

`skills/organize/SKILL.md` has:

```yaml
argument-hint: [--port <number>]
```

YAML parses the unquoted `[...]` value as a **flow sequence**, not a string. Copilot CLI 1.0.65 validates skill frontmatter and rejects `argument-hint` unless it is a string, so the skill fails to load there. Claude Code has been lenient about this so the bug has gone unnoticed.

This PR quotes the value so every YAML 1.1/1.2 parser reads it as a plain string:

```yaml
argument-hint: "[--port <number>]"
```

## YAML rule

- `argument-hint: [X]` -> flow sequence -> BAD. Fix: `argument-hint: "[X]"`.
- `argument-hint: ["X"]` -> single-element sequence containing a string -> BAD. Fix: `argument-hint: "X"`.
- If the intended hint itself contains a double quote, use single quotes: `argument-hint: '["foo"]'`.

`.claude-plugin/skills/organize.md` already uses the quoted form (`argument-hint: "[port]"`), so no change needed there.

## Files changed

- `skills/organize/SKILL.md` (1 line)

## Test plan

- [x] `python3 -c 'import yaml; ...'` on the patched file returns `str` for `argument-hint`, value `[--port <number>]`.
- [x] Full-repo `rg 'argument-hint:'` shows only two shipped skill files; both now parse as strings. (`research/datasets/routeguard_external_v0.json` matches are external corpus data used by the activation-scanner benchmark, not shipped skills.)
- [ ] Load the skill in Copilot CLI 1.0.65 and confirm it no longer errors on frontmatter validation.
- [ ] Load the skill in Claude Code and confirm the hint still displays.

## Context

Same class of bug tracked upstream at anthropics/claude-code#22161 - Copilot CLI's stricter frontmatter validation has surfaced YAML-array `argument-hint` fields across many public skills. This PR only patches this repo's copy.